### PR TITLE
Add basic user authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Goals
       {title: str, done: bool}
     - PUT /tasks/{id} → update title/done
     - DELETE /tasks/{id} → delete task
+    - POST /signup → create user account
+    - POST /login → authenticate user
   - Frontend features:
     - Add new tasks
     - List tasks from backend

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,28 @@
+import sys, os; sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import main
+from fastapi.testclient import TestClient
+
+client = TestClient(main.app)
+
+
+def setup_function():
+    main._users.clear()
+    main._next_user_id = 1
+
+
+def test_signup_and_login():
+    resp = client.post("/signup", json={"username": "alice", "password": "secret"})
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["username"] == "alice"
+    assert data["id"] == 1
+
+    resp = client.post("/signup", json={"username": "alice", "password": "secret"})
+    assert resp.status_code == 400
+
+    resp = client.post("/login", json={"username": "alice", "password": "secret"})
+    assert resp.status_code == 200
+    assert resp.json()["id"] == 1
+
+    resp = client.post("/login", json={"username": "alice", "password": "wrong"})
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- add simple in-memory user model and signup/login endpoints
- document new auth endpoints in README
- cover signup and login with tests

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac8db85a38832f98f7e6ad85cebe4a